### PR TITLE
Resolve the visual glitch of Mericus & Merikle.

### DIFF
--- a/psolib/src/commonMain/kotlin/world/phantasmal/psolib/fileFormats/quest/NpcType.kt
+++ b/psolib/src/commonMain/kotlin/world/phantasmal/psolib/fileFormats/quest/NpcType.kt
@@ -1071,8 +1071,8 @@ enum class NpcType(
         skin = 0,
         special = false,
     ),
-    Mericus(
-        uniqueName = "Mericus",
+    Merikle(
+        uniqueName = "Merikle",
         episode = Episode.II,
         enemy = true,
         areaIds = listOf(5, 6, 7, 8, 9, 16, 17),
@@ -1080,8 +1080,8 @@ enum class NpcType(
         skin = 1,
         special = false,
     ),
-    Merikle(
-        uniqueName = "Merikle",
+    Mericus(
+        uniqueName = "Mericus",
         episode = Episode.II,
         enemy = true,
         areaIds = listOf(5, 6, 7, 8, 9, 16, 17),
@@ -1490,6 +1490,6 @@ enum class NpcType(
         /**
          * Use this instead of [values] to avoid unnecessary copying.
          */
-        val VALUES: Array<NpcType> = values()
+        val VALUES: Array<NpcType> = entries.toTypedArray()
     }
 }

--- a/psolib/src/commonMain/kotlin/world/phantasmal/psolib/fileFormats/quest/NpcTypeFromData.kt
+++ b/psolib/src/commonMain/kotlin/world/phantasmal/psolib/fileFormats/quest/NpcTypeFromData.kt
@@ -104,8 +104,8 @@ fun npcTypeFromQuestNpc(npc: QuestNpc): NpcType {
         }
         0x0D6 -> when (skin % 3) {
             0 -> NpcType.Mericarol
-            1 -> NpcType.Mericus
-            else -> NpcType.Merikle
+            1 -> NpcType.Merikle
+            else -> NpcType.Mericus
         }
         0x0D7 -> when (skin % 2) {
             0 -> NpcType.UlGibbon


### PR DESCRIPTION
Description:
This PR fixes an issue where the monster IDs for Mericus (Green) and Merikle (Blue) were incorrectly swapped.
Mericus was showing the ID intended for Merikle, and vice versa. The mapping has now been corrected.

Changes:

Corrected monster ID assignment in the configuration/data file.

Verified visual and logic consistency for both monsters.